### PR TITLE
release(alpha): sync from dev@44eea8c [2026-05-21T00:54:12]

### DIFF
--- a/public/webhook_handler.php
+++ b/public/webhook_handler.php
@@ -2,8 +2,28 @@
 
 declare(strict_types=1);
 
-// Load Composer autoloader
-require_once __DIR__ . '/../vendor/autoload.php';
+// Load autoloader (prefer Composer's, fallback to a lightweight PSR-4 autoloader if vendor/ is missing in production)
+$autoloader = __DIR__ . '/../vendor/autoload.php';
+if (file_exists($autoloader)) {
+    require_once $autoloader;
+} else {
+    spl_autoload_register(static function (string $class): void {
+        $prefix = 'SimplePhpWebhook\\';
+        $baseDir = __DIR__ . '/../src/';
+
+        $len = strlen($prefix);
+        if (strncmp($prefix, $class, $len) !== 0) {
+            return;
+        }
+
+        $relativeClass = substr($class, $len);
+        $file = $baseDir . str_replace('\\', '/', $relativeClass) . '.php';
+
+        if (file_exists($file)) {
+            require_once $file;
+        }
+    });
+}
 
 use SimplePhpWebhook\Config\ConfigLoader;
 use SimplePhpWebhook\Logger\WebhookLogger;

--- a/src/WebhookHandler.php
+++ b/src/WebhookHandler.php
@@ -109,6 +109,7 @@ class WebhookHandler
             ];
         }
 
+
         // 6. Parse Repository and Branch
         $repository = $data['repository']['full_name'] ?? 'unknown';
         $ref = $data['ref'] ?? '';


### PR DESCRIPTION
This pull request improves the autoloading mechanism in `public/webhook_handler.php` to make the application more robust in production environments where the Composer `vendor/` directory may be missing. The main change is the addition of a fallback PSR-4 autoloader, ensuring that class loading works even without Composer's autoloader. There is also a minor formatting change in `src/WebhookHandler.php`.

Autoloading improvements:

* Updated `public/webhook_handler.php` to check for the Composer autoloader and fall back to a lightweight PSR-4 autoloader if `vendor/` is missing, improving reliability in production deployments.

Minor code formatting:

* Added a blank line for readability in the `handle` method of `src/WebhookHandler.php`.